### PR TITLE
verify script separated

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "verify": "yarn workspace @fil-frame/hardhat etherscan-verify",
     "hardhat-verify": "yarn workspace @fil-frame/hardhat verify",
     "deploy": "yarn workspace @fil-frame/hardhat deploy",
+    "deploy:verify": "yarn workspace @fil-frame/hardhat deploy:verify",
     "chain": "yarn workspace @fil-frame/hardhat chain",
     "test": "yarn workspace @fil-frame/hardhat test",
     "dev": "yarn workspace @fil-frame/nextjs dev",

--- a/packages/hardhat/.gitignore
+++ b/packages/hardhat/.gitignore
@@ -8,6 +8,7 @@ cache_forge
 # Hardhat files
 /cache
 /artifacts
+/deployments
 
 # TypeChain files
 /typechain

--- a/packages/hardhat/deploy/00_deploy_your_contract.ts
+++ b/packages/hardhat/deploy/00_deploy_your_contract.ts
@@ -45,25 +45,30 @@ const deployYourContract: DeployFunction = async function (
   );
   console.log("👋 Initial greeting:", await yourContract.greeting());
 
-  // Timeout for 10 Seconds to wait for the contract to be indexed on explorer
-  console.log(
-    "⏳ Waiting for 10 seconds for the contract to be indexed on the explorer..."
-  );
-  await new Promise((resolve) => setTimeout(resolve, 10000));
+  // Check if the --verify flag is present
+  const shouldVerify = process.env.VERIFY === "true";
 
-  console.log("🕵️‍♂️ Verifying the contract on the explorer...");
+  if (shouldVerify) {
+    // Timeout for 10 Seconds to wait for the contract to be indexed on explorer
+    console.log(
+      "⏳ Waiting for 10 seconds for the contract to be indexed on the explorer..."
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10000));
 
-  const filecoinNetworks = ["calibration", "filecoin"];
-  if (filecoinNetworks.includes(hre.network.name)) {
-    // Verify the contract on the filfox explorer
-    await hre.run("verifyContract", {
-      contractName: "YourContract",
-    });
-  } else {
-    await hre.run("verify:verify", {
-      address: YourContractAddress,
-      constructorArguments: [deployer],
-    });
+    console.log("🕵️‍♂️ Verifying the contract on the explorer...");
+
+    const filecoinNetworks = ["calibration", "filecoin"];
+    if (filecoinNetworks.includes(hre.network.name)) {
+      // Verify the contract on the filfox explorer
+      await hre.run("verifyContract", {
+        contractName: "YourContract",
+      });
+    } else {
+      await hre.run("verify:verify", {
+        address: YourContractAddress,
+        constructorArguments: [deployer],
+      });
+    }
   }
 };
 

--- a/packages/hardhat/hardhat.config.ts
+++ b/packages/hardhat/hardhat.config.ts
@@ -1,15 +1,15 @@
-import { HardhatUserConfig } from "hardhat/config";
-import { config as dotenvConfig } from "dotenv";
-import "@nomicfoundation/hardhat-foundry";
-import "@nomicfoundation/hardhat-ethers";
+import "./tasks/verifyContract";
 import "@nomicfoundation/hardhat-chai-matchers";
-import "@typechain/hardhat";
-import "hardhat-gas-reporter";
-import "solidity-coverage";
+import "@nomicfoundation/hardhat-ethers";
+import "@nomicfoundation/hardhat-foundry";
 import "@nomicfoundation/hardhat-verify";
+import "@typechain/hardhat";
+import { config as dotenvConfig } from "dotenv";
 import "hardhat-deploy";
 import "hardhat-deploy-ethers";
-import "./tasks/verifyContract";
+import "hardhat-gas-reporter";
+import { HardhatUserConfig } from "hardhat/config";
+import "solidity-coverage";
 
 dotenvConfig();
 const providerApiKey =

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -7,6 +7,7 @@
     "chain": "hardhat node --network hardhat",
     "compile": "hardhat compile",
     "deploy": "hardhat deploy",
+    "deploy:verify": "VERIFY=true hardhat deploy",
     "fork": "MAINNET_FORKING_ENABLED=true hardhat node --network hardhat",
     "generate": "hardhat run scripts/generateAccount.ts",
     "flatten": "hardhat flatten",


### PR DESCRIPTION
## Description

- adds separate script `deploy:verify` to verify the contracts along with deployment to separate deployment and verification as per user need.

## Additional Information

- [X] I have read the [contributing docs](/fil-frame/fil-frame-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [X] This is not a duplicate of any [existing pull request](https://github.com/fil-frame/fil-frame-2/pulls)
