### PR TITLE
filfox now shows correct read/write function even with complex contracts

### DIFF
--- a/packages/hardhat/tasks/verifyContract.ts
+++ b/packages/hardhat/tasks/verifyContract.ts
@@ -82,13 +82,12 @@ function extractVerificationData(network: string, contractName: string) {
   const solhint: SolhintData = JSON.parse(fs.readFileSync(solhintPath, "utf8"));
 
   // Extract the necessary data from the deployments and solhint files
-  const sourceFiles = Object.keys(solhint.sources).reduce(
-    (acc: any, key: string) => {
+  const sourceFiles = Object.keys(solhint.sources)
+    .reverse()
+    .reduce((acc: any, key: string) => {
       acc[key.split("contracts/")[1]] = solhint.sources[key];
       return acc;
-    },
-    {}
-  );
+    }, {});
 
   const { compiler, language } = JSON.parse(deployments.metadata) as {
     compiler: {


### PR DESCRIPTION
By reversing the order of the provided source codes, Filfox now correctly identifies the contract name as the first source code, whereas previously it was treated as the last. This adjustment ensures that Filfox displays the correct contract and its read/write functions properly on the explorer. This minor change makes the contract verification fully functional, allowing users to seamlessly interact with contracts directly from the explorer.