### PR TITLE
Fix: Nonce too low error on 2nd contract deploy

### DIFF
--- a/packages/hardhat/deploy/00_deal_client.ts
+++ b/packages/hardhat/deploy/00_deal_client.ts
@@ -33,6 +33,7 @@ const deployDealClient: DeployFunction = async function (
     // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
     // automatically mining the contract deployment transaction. There is no effect on live networks.
     autoMine: true,
+    waitConfirmations: 3,
   });
 
   console.log("🚀 DealClient deployed at: ", DealClient.address);

--- a/packages/hardhat/deploy/01_deal_info.ts
+++ b/packages/hardhat/deploy/01_deal_info.ts
@@ -20,11 +20,6 @@ const deployDealInfo: DeployFunction = async function (
     with a random private key in the .env file (then used on hardhat.config.ts)
     You can run the `yarn account` command to check your balance in every network.
   */
-
-  // Wait 30 seconds to ensure DealClient deployment is complete
-  console.log("⏳ Waiting for 30 seconds to ensure transaction is processed...");
-  await new Promise(resolve => setTimeout(resolve, 30000));
-
   const [deployerSigner] = await hre.ethers.getSigners();
   const deployer = await deployerSigner.getAddress();
 

--- a/packages/hardhat/deploy/01_deal_info.ts
+++ b/packages/hardhat/deploy/01_deal_info.ts
@@ -20,6 +20,11 @@ const deployDealInfo: DeployFunction = async function (
     with a random private key in the .env file (then used on hardhat.config.ts)
     You can run the `yarn account` command to check your balance in every network.
   */
+
+  // Wait 30 seconds to ensure DealClient deployment is complete
+  console.log("⏳ Waiting for 30 seconds to ensure transaction is processed...");
+  await new Promise(resolve => setTimeout(resolve, 30000));
+
   const [deployerSigner] = await hre.ethers.getSigners();
   const deployer = await deployerSigner.getAddress();
 


### PR DESCRIPTION
## Description
- When following README and doing `yarn deploy` we get a nonce too low error due to the sequential contract deployments. Adding a 30s wait time after the first one is deployed fixes this.
- I tried using hardhat's await for the 1st contract and adding the 1st contract as a dependency, but neither solutions worked so I resorted with the 30s wait (30 was an arbitrary number)

## Additional Information

- [x] I have read the [contributing docs](/fil-frame/fil-frame-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/FIL-Builders/fil-frame/pulls)

## Related Issues

_Closes #60_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
