### PR TITLE
Fix: Remove 10s wait from contract verify

### DIFF
--- a/packages/hardhat/deploy/00_deal_client.ts
+++ b/packages/hardhat/deploy/00_deal_client.ts
@@ -43,12 +43,6 @@ const deployDealClient: DeployFunction = async function (
   const shouldVerify = process.env.VERIFY === "true";
 
   if (shouldVerify) {
-    // Timeout for 10 Seconds to wait for the contract to be indexed on explorer
-    console.log(
-      "⏳ Waiting for 10 seconds for the contract to be indexed on the explorer..."
-    );
-    await new Promise((resolve) => setTimeout(resolve, 10000));
-
     console.log("🕵️‍♂️ Verifying the contract on the explorer...");
 
     const filecoinNetworks = ["calibration", "filecoin"];


### PR DESCRIPTION
## Description
- Now that `waitConfirmations: 3` is added when deploying DealClient, the 10s wait before verifying the contract is not needed
- The 10s wait for DealInfo (2nd contract deploy) is still there, as during deploy that contract doesn't wait for block confirmations

## Additional Information

- [x] I have read the [contributing docs](/fil-frame/fil-frame-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/FIL-Builders/fil-frame/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
